### PR TITLE
fix crash when SMR file is closed

### DIFF
--- a/MGU/Forms/MainStuff.cs
+++ b/MGU/Forms/MainStuff.cs
@@ -1478,7 +1478,7 @@ namespace MGU
         public void ClearGame()
         {
             contextMenu1.MenuItems.Clear();
-            contextMenu0.MenuItems.RemoveAt(currentGame-1);
+            contextMenu0.MenuItems.RemoveAt(currentGame);
 
             //Remove all sector objects
             for (int g = 0; g < games[currentGame].nrofgalaxies; g++)


### PR DESCRIPTION
start MGU, open a game universe
file > close game universe > answer no to saving and MGU will crash
this leads to further issues with accessing multiple SMR files at the same time but this fixes the most common problem at the moment.