### PR TITLE
Race "Neutral" is being set to 0 instead of 1.

### DIFF
--- a/MGU/Classes/Game.cs
+++ b/MGU/Classes/Game.cs
@@ -85,7 +85,7 @@ namespace MGU
             race = new Race[nrofraces+1];
             peace = new bool[nrofraces + 1];
 
-            for (int i = 0; i < nrofraces + 1; i++)
+            for (int i = 1; i < nrofraces + 1; i++)
             {
                 race[i] = new Race();
                 peace[i] = false;

--- a/MGU/Classes/Race.cs
+++ b/MGU/Classes/Race.cs
@@ -27,7 +27,7 @@ namespace MGU
         public ushort GetRaceNameAsId(Game currentGame)
 	//This function returns the index of a race within a given game
         {
-            for (int i = 0; i <= currentGame.nrofraces; i++)
+            for (int i = 1; i <= currentGame.nrofraces; i++)
                 if (currentGame.race[i].race_name == this.race_name)
                     return (ushort) i;
             


### PR DESCRIPTION
From discord: 
> stupid newbie Today at 3:32 PM
> Last I knew MGU was ignoring neutral ports. I'd keep watch for that if you are computing routes.

In the `GetRaceNameAsId()` method `race_name` for `"Neutral"` ports is set to 0 since there are always two `"Neutral"` ports in the race array. This prevents including "Neutral" ports in route planning. It also rewrites a sector's port race in `.smu` files from `1` to `0`.  

This fix returns `1` for "Neutral ports". 