### PR TITLE
trim lines when loading .smr file

### DIFF
--- a/MGU/Classes/SMR16.cs
+++ b/MGU/Classes/SMR16.cs
@@ -68,6 +68,13 @@ namespace MGU
             //Split the entire file into individual lines
             char[] delim = { '\n', '\r' };
             ArrayList lines = new ArrayList(data.ReadToEnd().Split(delim, StringSplitOptions.RemoveEmptyEntries));
+
+            //Trim lines
+            for (int l = 0; l < lines.Count; l++)
+            {
+                lines[l] = lines[l].ToString().Trim();                 
+            }
+
             ForceData forces;
 
             int i, j, nrofcomments = 0;


### PR DESCRIPTION
Tabs in `.smr` files prevent loading data correctly within MGU. Added `\t` to the list of delimiters when reading in the file. 

The files seem to load correctly now.