### PR TITLE
Handle no-drop zones

### DIFF
--- a/MGU/Classes/Sector.cs
+++ b/MGU/Classes/Sector.cs
@@ -294,7 +294,12 @@ namespace MGU
             for (int l = 0; l < nroflocations; l++)
             {
                 lindex = currentGame.GetLocationIconIndex(currentGame.location[this.location[l]]);
-                e.Graphics.DrawImage(currentGame.Locations.Images[lindex], (currentGame.sectorsize / 2) - ((float)(currentGame.sectorsize / 7.5) * (nroflocations / 2)) + (float)(currentGame.sectorsize / 8) * l, currentGame.sectorsize / 2 - (float)(currentGame.sectorsize / 15), (float)(currentGame.sectorsize / 7.5), (float)(currentGame.sectorsize / 7.5));
+
+                // Check for valid location icon 
+                if (lindex >= 0 && lindex < currentGame.Locations.Images.Count)
+                {
+                    e.Graphics.DrawImage(currentGame.Locations.Images[lindex], (currentGame.sectorsize / 2) - ((float)(currentGame.sectorsize / 7.5) * (nroflocations / 2)) + (float)(currentGame.sectorsize / 8) * l, currentGame.sectorsize / 2 - (float)(currentGame.sectorsize / 15), (float)(currentGame.sectorsize / 7.5), (float)(currentGame.sectorsize / 7.5));
+                }                
             }
 
             //DrawFocus(e.Graphics);


### PR DESCRIPTION
SMR player Target mentioned that MGU was not working for newer games because of No-Drop Zones. 

In the sector file, the inclusion of the No-Drop Zone location will crash the application when opening the game universe. MGU parses the `.smr` file by to set the location name and type. If no location type is included then an error occurs when drawing sectors. The `No-Drop Zone` location has no type specified in the `.smr` files. 

This adds support for No-Drop Zones and future locations that may not have a type by simply setting the location type to the name of the location.

I've also added the NDZ icon from the game into the location icons so it will display in the MGU map. 

